### PR TITLE
Don't build the wapproj for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,11 +25,6 @@ jobs:
       run: |
         & "${{ steps.vsdevcmd.outputs.install_path }}\MSBuild\Current\bin\msbuild.exe" /nologo /t:Restore
     - name: Build
-      working-directory: ./src/MSIExtract.AppxPackage
+      working-directory: ./src/MSIExtract
       run: |
         & "${{ steps.vsdevcmd.outputs.install_path }}\MSBuild\Current\bin\msbuild.exe" /nologo /m /p:Configuration=Release /p:Platform=x64
-    - uses: actions/upload-artifact@v1.0.0
-      name: Upload MSIX Package
-      with:
-        name: MSIX Packages
-        path: bin/AppxPackages


### PR DESCRIPTION
This slows down CI significantly, and there is little reason to have AppX packages saved for pull requests.