### PR TITLE
Enable the shell command if the selection is mixed

### DIFF
--- a/src/MSIExtract.ShellExtension/MSIViewerOpenCommand.cs
+++ b/src/MSIExtract.ShellExtension/MSIViewerOpenCommand.cs
@@ -29,7 +29,7 @@ namespace MSIExtract.ShellExtension
                 throw new ArgumentNullException(nameof(selectedFiles));
             }
 
-            return selectedFiles.All(IsMSIFile) ? ExplorerCommandState.Enabled : ExplorerCommandState.Disabled;
+            return selectedFiles.Any(IsMSIFile) ? ExplorerCommandState.Enabled : ExplorerCommandState.Hidden;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
With this change applied, the shell command will be enabled if any of the selected files are MSI files; since `Invoke()` already ignores non-MSI files, there is no need to disable the command if any are detected.