### PR TITLE
Remove absolute paths from publish profiles

### DIFF
--- a/RepoRoot.props
+++ b/RepoRoot.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <RepoRootPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\'))</RepoRootPath>
+    <BaseIntermediateOutputPath>$(RepoRootPath)obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
+    <BaseOutputPath>$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
+    <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\</PackageOutputPath>
+  </PropertyGroup>
+</Project>

--- a/src/Cpp.Build.props
+++ b/src/Cpp.Build.props
@@ -1,7 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <RepoRootPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\'))</RepoRootPath>
-    <OutDir>$(RepoRootPath)bin\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(RepoRootPath)obj\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,10 +1,8 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\RepoRoot.props" />
+  
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <RepoRootPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\'))</RepoRootPath>
-    <BaseIntermediateOutputPath>$(RepoRootPath)obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
-    <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
-    <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\</PackageOutputPath>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MSIExtract.ShellExtension/Properties/PublishProfiles/Debug_x64.pubxml
+++ b/src/MSIExtract.ShellExtension/Properties/PublishProfiles/Debug_x64.pubxml
@@ -3,12 +3,14 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\RepoRoot.props" />
+
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Debug</Configuration>
     <Platform>x64</Platform>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <PublishDir>D:\Projects\WixSharpApp\bin\MSIExtract.ShellExtension\x64\Debug\netcoreapp3.1\publish\</PublishDir>
+    <PublishDir>$(RepoRootDir)\bin\MSIExtract.ShellExtension\x64\Debug\netcoreapp3.1\publish\</PublishDir>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/src/MSIExtract.ShellExtension/Properties/PublishProfiles/Debug_x86.pubxml
+++ b/src/MSIExtract.ShellExtension/Properties/PublishProfiles/Debug_x86.pubxml
@@ -3,12 +3,14 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\RepoRoot.props" />
+
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Debug</Configuration>
     <Platform>x86</Platform>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <PublishDir>D:\Projects\WixSharpApp\bin\MSIExtract.ShellExtension\x86\Debug\netcoreapp3.1\publish\</PublishDir>
+    <PublishDir>$(RepoRootDir)\bin\MSIExtract.ShellExtension\x86\Debug\netcoreapp3.1\publish\</PublishDir>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/src/MSIExtract.ShellExtension/Properties/PublishProfiles/Release_x64.pubxml
+++ b/src/MSIExtract.ShellExtension/Properties/PublishProfiles/Release_x64.pubxml
@@ -3,12 +3,14 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\RepoRoot.props" />
+
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Release</Configuration>
     <Platform>x64</Platform>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <PublishDir>D:\Projects\WixSharpApp\bin\MSIExtract.ShellExtension\x64\Release\netcoreapp3.1\publish\</PublishDir>
+    <PublishDir>$(RepoRootDir)\bin\MSIExtract.ShellExtension\x64\Release\netcoreapp3.1\publish\</PublishDir>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/src/MSIExtract.ShellExtension/Properties/PublishProfiles/Release_x86.pubxml
+++ b/src/MSIExtract.ShellExtension/Properties/PublishProfiles/Release_x86.pubxml
@@ -3,12 +3,14 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\RepoRoot.props" />
+
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Release</Configuration>
     <Platform>x86</Platform>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <PublishDir>D:\Projects\WixSharpApp\bin\MSIExtract.ShellExtension\x86\Release\netcoreapp3.1\publish\</PublishDir>
+    <PublishDir>$(RepoRootDir)\bin\MSIExtract.ShellExtension\x86\Release\netcoreapp3.1\publish\</PublishDir>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/src/MSIExtract/Properties/PublishProfiles/Debug_x64.pubxml
+++ b/src/MSIExtract/Properties/PublishProfiles/Debug_x64.pubxml
@@ -3,12 +3,14 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\RepoRoot.props" />
+
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Debug</Configuration>
     <Platform>x64</Platform>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <PublishDir>D:\Projects\WixSharpApp\bin\MSIExtract\x64\Debug\netcoreapp3.1\publish\</PublishDir>
+    <PublishDir>$(RepoRootPath)\bin\MSIExtract\x64\Debug\netcoreapp3.1\publish\</PublishDir>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/src/MSIExtract/Properties/PublishProfiles/Debug_x86.pubxml
+++ b/src/MSIExtract/Properties/PublishProfiles/Debug_x86.pubxml
@@ -3,12 +3,14 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\RepoRoot.props" />
+
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Debug</Configuration>
     <Platform>x86</Platform>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <PublishDir>D:\Projects\WixSharpApp\bin\MSIExtract\x86\Debug\netcoreapp3.1\publish\</PublishDir>
+    <PublishDir>$(RepoRootDir)\bin\MSIExtract\x86\Debug\netcoreapp3.1\publish\</PublishDir>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/src/MSIExtract/Properties/PublishProfiles/Release_x64.pubxml
+++ b/src/MSIExtract/Properties/PublishProfiles/Release_x64.pubxml
@@ -3,12 +3,14 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\RepoRoot.props" />
+
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Release</Configuration>
     <Platform>x64</Platform>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <PublishDir>D:\Projects\WixSharpApp\bin\MSIExtract\x64\Release\netcoreapp3.1\publish\</PublishDir>
+    <PublishDir>$(RepoRootDir)\bin\MSIExtract\x64\Release\netcoreapp3.1\publish\</PublishDir>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/src/MSIExtract/Properties/PublishProfiles/Release_x86.pubxml
+++ b/src/MSIExtract/Properties/PublishProfiles/Release_x86.pubxml
@@ -3,12 +3,14 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\RepoRoot.props" />
+
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Release</Configuration>
     <Platform>x86</Platform>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <PublishDir>D:\Projects\WixSharpApp\bin\MSIExtract\x86\Release\netcoreapp3.1\publish\</PublishDir>
+    <PublishDir>$(RepoRootDir)\bin\MSIExtract\x86\Release\netcoreapp3.1\publish\</PublishDir>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/src/MSIExtractApp.sln
+++ b/src/MSIExtractApp.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.targets = Directory.Build.targets
 		..\global.json = ..\global.json
 		..\nuget.config = ..\nuget.config
+		..\RepoRoot.props = ..\RepoRoot.props
 		shipping.ruleset = shipping.ruleset
 		stylecop.json = stylecop.json
 		tests.ruleset = tests.ruleset

--- a/src/MSIExtractApp.sln
+++ b/src/MSIExtractApp.sln
@@ -6,7 +6,6 @@ MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1CE9670B-D5FF-46A7-9D00-24E70E6ED48B}"
 	ProjectSection(SolutionItems) = preProject
 		..\.editorconfig = ..\.editorconfig
-		Cpp.Build.props = Cpp.Build.props
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		..\global.json = ..\global.json


### PR DESCRIPTION
I also took the opportunity to remove `Cpp.Build.props`, which is now unused.