### PR TITLE
Move certificate thumbprint to non-committed file

### DIFF
--- a/src/MSIExtract.AppxPackage/.gitignore
+++ b/src/MSIExtract.AppxPackage/.gitignore
@@ -1,0 +1,1 @@
+/Signing.props

--- a/src/MSIExtract.AppxPackage/Directory.Build.props
+++ b/src/MSIExtract.AppxPackage/Directory.Build.props
@@ -4,4 +4,6 @@
     <BaseIntermediateOutputPath>..\..\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
     <AppxPackageDir>..\..\bin\AppxPackages</AppxPackageDir>
   </PropertyGroup>
+
+  <Import Project="Signing.props" Condition="Exists('Signing.props')" />
 </Project>

--- a/src/MSIExtract.AppxPackage/MSIExtract.AppxPackage.wapproj
+++ b/src/MSIExtract.AppxPackage/MSIExtract.AppxPackage.wapproj
@@ -40,7 +40,6 @@
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
     <OutputPath>$(BaseOutputPath)$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Platform)\$(Configuration)\</IntermediateOutputPath>
-    <PackageCertificateThumbprint>1FBBBCB81D93AB1DD616944776CF6FAB8C317B03</PackageCertificateThumbprint>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <AppxBundle>Always</AppxBundle>
@@ -60,6 +59,7 @@
     </AppxManifest>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Signing.props" />
     <None Include="Package.StoreAssociation.xml" />
     <None Include="Directory.Build.props" />
     <None Include="Directory.Build.targets" />


### PR DESCRIPTION
While this is not sensitive information, it does vary between computers. Storing it this way decreases repo churn.