### PR TITLE
Make shell extension understand MSM files

### DIFF
--- a/src/MSIExtract.ShellExtension/MSIViewerOpenCommand.cs
+++ b/src/MSIExtract.ShellExtension/MSIViewerOpenCommand.cs
@@ -60,6 +60,6 @@ namespace MSIExtract.ShellExtension
             }
         }
 
-        private static bool IsMSIFile(string path) => Path.GetExtension(path) == ".msi";
+        private static bool IsMSIFile(string path) => Path.GetExtension(path) == ".msi" || Path.GetExtension(path) == ".msm";
     }
 }


### PR DESCRIPTION
Previously, it would enabled itself only on MSI files.