### PR TITLE
Hardcode the AppX signing key password

### DIFF
--- a/src/MSIExtract.AppxPackage/Signing.props
+++ b/src/MSIExtract.AppxPackage/Signing.props
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <PackageCertificateThumbprint>4DFF1FA5A339F7C1F623177264249E99D4C81E45</PackageCertificateThumbprint>
     <PackageCertificateKeyFile>cert.pfx</PackageCertificateKeyFile>
+    <PackageCertificatePassword>1234</PackageCertificatePassword>
   </PropertyGroup>
 </Project>

--- a/tools/make-certificate.ps1
+++ b/tools/make-certificate.ps1
@@ -1,12 +1,6 @@
 param(
     [Parameter(Mandatory)]
     [string]$OutputPath,
-
-    [Parameter(Mandatory)]
-    [string]$Password,
-
-    [Parameter(Mandatory)]
-    [string]$ThumbprintFile
 )
 
 # N.B. This must be kept in sync with the Package/Publisher/@Identity
@@ -20,6 +14,6 @@ $cert = New-SelfSignedCertificate -Type Custom -Subject $signer_name -KeyUsage D
 	-TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}") `
 	-KeyExportPolicy Exportable
 
+$Password = "1234"
 $pwd = ConvertTo-SecureString $Password -AsPlainText
 Export-PfxCertificate -Cert $cert -Password $pwd -FilePath $OutputPath
-Set-Content $ThumbprintFile $cert.Thumbprint


### PR DESCRIPTION
Since this is a self-signed key valid only for the Microsoft Store, I do not believe this introduces a security risk. In fact, it is required so that GitHub Actions can correctly sign the package.