### PR TITLE
Allow project to run outside an AppX container

### DIFF
--- a/src/MSIExtract/App.xaml.cs
+++ b/src/MSIExtract/App.xaml.cs
@@ -26,24 +26,6 @@ namespace MSIExtract
         {
             base.OnStartup(e);
 
-            if (!CheckPackageIdentity())
-            {
-                var page = new TaskDialogPage
-                {
-                    AllowCancel = true,
-                    Title = "MSI Viewer",
-                    Instruction = "MSI Viewer cannot be run outside of its Windows Store package.",
-                    Icon = TaskDialogIcon.Get(TaskDialogStandardIcon.Error),
-                };
-
-                page.StandardButtons.Add(TaskDialogResult.Close);
-                var td = new TaskDialog(page);
-                td.Show();
-
-                this.Shutdown();
-                return;
-            }
-
             ThemeManager.Install();
             AeroTheme.SetAsCurrentTheme();
 


### PR DESCRIPTION
I gain nothing by doing this; the only call in the program that requires package identity is wrapped in a try/catch so any failure there is ignored.