### PR TITLE
Add a new tab showing all MSI tables present

### DIFF
--- a/src/MSIExtract.Core/Msi/MsiDataContainer.cs
+++ b/src/MSIExtract.Core/Msi/MsiDataContainer.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using WixToolset.Dtf.WindowsInstaller;
+
+namespace MSIExtract.Msi
+{
+    public class MsiDataContainer
+    {
+        readonly MsiFile[] files;
+        readonly TableWithData[] tables;
+
+        /// <summary>
+        /// A list of installable files present in the database.
+        /// </summary>
+        public MsiFile[] Files => this.files;
+
+        /// <summary>
+        /// The raw view of the tables in the database.
+        /// </summary>
+        public TableWithData[] Tables => this.tables;
+
+        /// <summary>
+        /// Creates a <see cref="MsiDataContainer"/> object from the specified database.
+        /// This contains a list of the files in the database, and all tables.
+        /// </summary>
+        public static MsiDataContainer CreateFromPath(LessIO.Path msiDatabaseFilePath)
+        {
+            return new MsiDataContainer(msiDatabaseFilePath);
+        }
+
+        private MsiDataContainer(LessIO.Path msiDatabaseFilePath)
+        {
+            using var db = new Database(msiDatabaseFilePath.PathString, DatabaseOpenMode.ReadOnly);
+            this.files = MsiFile.CreateMsiFilesFromMSI(db);
+
+            this.tables = db.Tables.OrderBy(tab => tab.Name).Select(table => TableWithData.Create(db, table.Name)).ToArray();
+        }
+    }
+}

--- a/src/MSIExtract.Core/Msi/TableWithData.cs
+++ b/src/MSIExtract.Core/Msi/TableWithData.cs
@@ -1,0 +1,72 @@
+﻿using System.Data;
+using WixToolset.Dtf.WindowsInstaller;
+
+namespace MSIExtract.Msi
+{
+    public class TableWithData
+    {
+        public string Name { get; private set; }
+
+        public bool IsEmpty { get; private set; }
+
+        public DataTable Rows { get; private set; }
+
+        internal static TableWithData Create(Database db, string name)
+        {
+            TableRow[] rows = TableRow.GetRowsFromTable(db, name, out ColumnInfo[] columns);
+
+            var hasSequence = false;
+            var dt = new DataTable();
+            foreach (ColumnInfo col in columns)
+            {
+                // Allow integer columns to be sorted naturally
+                if (col.IsInteger)
+                {
+                    dt.Columns.Add(col.Name, typeof(int));
+                }
+                else
+                {
+                    dt.Columns.Add(col.Name);
+                }
+                hasSequence |= col.Name.ToUpper() == "SEQUENCE";
+            }
+
+            foreach(TableRow row in rows)
+            {
+                DataRow dtRow = dt.NewRow();
+                foreach (ColumnInfo col in columns)
+                {
+                    if (col.IsStream)
+                    {
+                        // TODO: Figure something out for this later.
+                        dtRow[col.Name] = "[Binary data]";
+                    }
+                    else
+                    {
+                        dtRow[col.Name] = row.GetValue(col.Name);
+                    }
+                }
+                dt.Rows.Add(dtRow);
+            }
+
+            // There are quite some data tables that have a 'Sequence' column,
+            // so we sort by that if this column is present
+            if (hasSequence)
+            {
+                DataView view = dt.DefaultView;
+                view.Sort = "SEQUENCE ASC";
+                dt = view.ToTable();
+            }
+            return new TableWithData(name)
+            {
+                IsEmpty = dt.Rows.Count == 0,
+                Rows = dt
+            };
+        }
+
+        private TableWithData(string name)
+        {
+            this.Name = name;
+        }
+    }
+}

--- a/src/MSIExtract.Core/Msi/TableWrapper.cs
+++ b/src/MSIExtract.Core/Msi/TableWrapper.cs
@@ -46,9 +46,15 @@ namespace MSIExtract.Msi
 
         public static TableRow[] GetRowsFromTable(Database msidb, string tableName)
         {
+            return GetRowsFromTable(msidb, tableName, out ColumnInfo[] _);
+        }
+
+        public static TableRow[] GetRowsFromTable(Database msidb, string tableName, out ColumnInfo[] columns)
+        {
             if (!msidb.Tables.Contains(tableName))
             {
                 Trace.WriteLine(string.Format("Table name does {0} not found.", tableName));
+                columns = null;
                 return new TableRow[0];
             }
 
@@ -57,7 +63,7 @@ namespace MSIExtract.Msi
             {
                 ArrayList /*<TableRow>*/ rows = new ArrayList(view.Records.Count);
 
-                ColumnInfo[] columns = view.Columns;
+                columns = view.Columns;
                 foreach (object[] values in view.Records)
                 {
                     HybridDictionary valueCollection = new HybridDictionary(values.Length);

--- a/src/MSIExtract/Model/AppModel.cs
+++ b/src/MSIExtract/Model/AppModel.cs
@@ -70,11 +70,11 @@ namespace MSIExtract
 
                 if (msiPath != null)
                 {
-                    MsiFile[] msiFiles;
+                    MsiDataContainer container;
 
                     try
                     {
-                        msiFiles = MsiFile.CreateMsiFilesFromMSI(new LessIO.Path(msiPath));
+                        container = MsiDataContainer.CreateFromPath(new LessIO.Path(msiPath));
                     }
                     catch
                     {
@@ -82,18 +82,22 @@ namespace MSIExtract
                         return;
                     }
 
-                    fileList.Source = msiFiles;
+                    fileList.Source = container.Files;
+                    Tables = new ObservableCollection<TableWithData>(container.Tables);
+
                     MRUModel.UpdateEntry(msiPath);
                     SaveMRU();
                 }
                 else
                 {
                     fileList.Source = Array.Empty<MsiFile>();
+                    Tables = new ObservableCollection<TableWithData>();
                 }
 
                 OnPropertyChanged(nameof(MsiPath));
                 OnPropertyChanged(nameof(IsMsiLoaded));
                 OnPropertyChanged(nameof(Files));
+                OnPropertyChanged(nameof(Tables));
                 OnPropertyChanged(nameof(MRUModel));
             }
         }
@@ -122,6 +126,11 @@ namespace MSIExtract
                 OnPropertyChanged(nameof(FilterText));
             }
         }
+
+        /// <summary>
+        /// Gets a collection of the table names from the MSI.
+        /// </summary>
+        public ObservableCollection<TableWithData> Tables { get; private set; } = new ObservableCollection<TableWithData>();
 
         /// <summary>
         /// Gets an <see cref="IMRUListViewModel"/> object that contains the list of recently opened MSI files.

--- a/src/MSIExtract/Views/MainWindow.xaml
+++ b/src/MSIExtract/Views/MainWindow.xaml
@@ -71,8 +71,16 @@
 
             <Controls:FilePicker x:Name="FilePicker" Grid.Row="0" Margin="6 4 4 0" Header="File:" HorizontalAlignment="Stretch"
                                  FilePath="{Binding Path=MsiPath, Mode=TwoWay}" OpenDialogFilter="MSI Files (*.msi, *.msm)|*.msi;*.msm" />
+            <TabControl Grid.Row="1" Margin="8">
+                <TabItem Header="Files">
+                    <Views:ExtractFilesView />
+                </TabItem>
+                <TabItem Header="Tables">
+                    <Views:TableView />
+                </TabItem>
+            </TabControl>
 
-            <Views:ExtractFilesView Grid.Row="1" Margin="8" />
+
         </Grid>
     </Grid>
 </Window>

--- a/src/MSIExtract/Views/TableView.xaml
+++ b/src/MSIExtract/Views/TableView.xaml
@@ -1,0 +1,44 @@
+﻿<UserControl x:Class="MSIExtract.Views.TableView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" mc:Ignorable="d"
+             xmlns:Controls="clr-namespace:MSIExtract.Controls"
+             xmlns:Views="clr-namespace:MSIExtract.Views"
+             xmlns:Msi="clr-namespace:MSIExtract.Msi;assembly=MSIExtract.Core"
+             d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{StaticResource DesignTimeAppModel}">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2*" />
+            <ColumnDefinition Width="5" />
+            <ColumnDefinition Width="5*" />
+        </Grid.ColumnDefinitions>
+
+        <ListBox Grid.Column="0" x:Name="TableNamesListBox" ItemsSource="{Binding Path=Tables}" IsEnabled="{Binding IsMsiLoaded}" >
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{Binding Name}" >
+                            <TextBlock.Style>
+                                <Style TargetType="{x:Type TextBlock}">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsEmpty}" Value="True">
+                                            <Setter Property="Foreground" Value="{x:Static SystemColors.GrayTextBrush}"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </StackPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+
+        <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" />
+
+        <DataGrid Grid.Column="2" DataContext="{Binding ElementName=TableNamesListBox,Path=SelectedItem}" ItemsSource="{Binding Path=Rows}"
+                  AutoGenerateColumns="True" SelectionMode="Single" IsReadOnly="True" CanUserResizeRows="False" CanUserReorderColumns="False" HeadersVisibility="Column" SelectionUnit="Cell" CanUserAddRows="False" CanUserDeleteRows="False" />
+
+
+    </Grid>
+</UserControl>

--- a/src/MSIExtract/Views/TableView.xaml.cs
+++ b/src/MSIExtract/Views/TableView.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace MSIExtract.Views
+{
+    /// <summary>
+    /// Interaction logic for TableView.xaml
+    /// </summary>
+    public partial class TableView : UserControl
+    {
+        public TableView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Very simple implementation using `DataTables` (I don't know enough WPF to make this better).
Empty tables are displayed as 'disabled'.

![image](https://user-images.githubusercontent.com/610685/103468811-7e3a9d80-4d5d-11eb-887b-99f94a6af9ee.png)
