### PR TITLE
Make app require the same OS build as the AppX manifest

### DIFF
--- a/src/LessIO/LessIO.csproj
+++ b/src/LessIO/LessIO.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net5.0-windows10.0.17763</TargetFramework>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <IsThirdPartyProject>true</IsThirdPartyProject>
     <NoWarn>CS1591</NoWarn>

--- a/src/MSIExtract.Core/MSIExtract.Core.csproj
+++ b/src/MSIExtract.Core/MSIExtract.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net5.0-windows10.0.17763</TargetFramework>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <IsThirdPartyProject>true</IsThirdPartyProject>
     <UseWPF>true</UseWPF>

--- a/src/MSIExtract.ShellExtension/MSIExtract.ShellExtension.csproj
+++ b/src/MSIExtract.ShellExtension/MSIExtract.ShellExtension.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.SDK">
   <PropertyGroup>
-    <TargetFramework>net5.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net5.0-windows10.0.17763</TargetFramework>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <NoWarn>CA1714</NoWarn>
     <Platforms>x64;x86</Platforms>

--- a/src/MSIExtract/MSIExtract.csproj
+++ b/src/MSIExtract/MSIExtract.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net5.0-windows10.0.17763</TargetFramework>
     <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
     <Platforms>x86;x64</Platforms>
     <UseWindowsForms>true</UseWindowsForms>

--- a/src/MSIExtract/MSIExtract.csproj
+++ b/src/MSIExtract/MSIExtract.csproj
@@ -11,6 +11,8 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Setup.ico</ApplicationIcon>
     <NoWarn>CS8002;CA1303;CA1416;SA1101;IDE0009;NU1701</NoWarn>
+
+    <IncludePackageReferencesDuringMarkupCompilation>false</IncludePackageReferencesDuringMarkupCompilation>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TaskDialog/TaskDialog.csproj
+++ b/src/TaskDialog/TaskDialog.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net5.0-windows10.0.17763</TargetFramework>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <AssemblyName>TaskDialog</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/src/WixToolset.Dtf.Compression.Cab/WixToolset.Dtf.Compression.Cab.csproj
+++ b/src/WixToolset.Dtf.Compression.Cab/WixToolset.Dtf.Compression.Cab.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net5.0-windows10.0.17763</TargetFramework>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <IsThirdPartyProject>true</IsThirdPartyProject>
     <Nullable>disable</Nullable>

--- a/src/WixToolset.Dtf.Compression/WixToolset.Dtf.Compression.csproj
+++ b/src/WixToolset.Dtf.Compression/WixToolset.Dtf.Compression.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net5.0-windows10.0.17763</TargetFramework>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <IsThirdPartyProject>true</IsThirdPartyProject>
     <Nullable>disable</Nullable>

--- a/src/WixToolset.Dtf.WindowsInstaller/WixToolset.Dtf.WindowsInstaller.csproj
+++ b/src/WixToolset.Dtf.WindowsInstaller/WixToolset.Dtf.WindowsInstaller.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net5.0-windows10.0.17763</TargetFramework>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <IsThirdPartyProject>true</IsThirdPartyProject>
     <Nullable>disable</Nullable>


### PR DESCRIPTION
The MSIX package was targeting downlevel to 17763, but the rest of the project targets 19041. This has now been remedied.