### PR TITLE
Disable ReadyToRun during publish

### DIFF
--- a/src/MSIExtract/Properties/PublishProfiles/Release_ARM64.pubxml
+++ b/src/MSIExtract/Properties/PublishProfiles/Release_ARM64.pubxml
@@ -12,6 +12,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
+    <PublishReadyToRun>False</PublishReadyToRun>
   </PropertyGroup>
 </Project>

--- a/src/MSIExtract/Properties/PublishProfiles/Release_x64.pubxml
+++ b/src/MSIExtract/Properties/PublishProfiles/Release_x64.pubxml
@@ -14,6 +14,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
+    <PublishReadyToRun>False</PublishReadyToRun>
   </PropertyGroup>
 </Project>

--- a/src/MSIExtract/Properties/PublishProfiles/Release_x86.pubxml
+++ b/src/MSIExtract/Properties/PublishProfiles/Release_x86.pubxml
@@ -12,6 +12,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
+    <PublishReadyToRun>False</PublishReadyToRun>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This causes issues on the build server when cutting a release.