### PR TITLE
Fixes for GitHub Actions issues

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -57,7 +57,7 @@ jobs:
                   $manifest.Save('.\src\MSIExtract.AppxPackage\Package.appxmanifest')
                 }
 
-                echo "::set-output name=version::$version"
+                echo "version=$version" >> $GITHUB_OUTPUT
 
             - name: Nerdbank.GitVersioning
               uses: dotnet/nbgv@master

--- a/src/LessIO/LessIO.csproj
+++ b/src/LessIO/LessIO.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0-windows10.0.22000</TargetFramework>
-    <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <IsThirdPartyProject>true</IsThirdPartyProject>
     <NoWarn>CS1591</NoWarn>
     <Platforms>AnyCPU;ARM64</Platforms>

--- a/src/MSIExtract.Core/MSIExtract.Core.csproj
+++ b/src/MSIExtract.Core/MSIExtract.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0-windows10.0.22000</TargetFramework>
-    <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <IsThirdPartyProject>true</IsThirdPartyProject>
     <UseWPF>true</UseWPF>
 

--- a/src/MSIExtract/MSIExtract.csproj
+++ b/src/MSIExtract/MSIExtract.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net9.0-windows10.0.22000</TargetFramework>
-    <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <Platforms>x86;x64;ARM64</Platforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseWindowsForms>true</UseWindowsForms>

--- a/src/ShellCommandLib/ShellCommandLib.csproj
+++ b/src/ShellCommandLib/ShellCommandLib.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0-windows10.0.22000</TargetFramework>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <Platforms>x86;x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Shmuelie.WinRTServer/Shmuelie.WinRTServer.csproj
+++ b/src/Shmuelie.WinRTServer/Shmuelie.WinRTServer.csproj
@@ -5,7 +5,7 @@
     <PackageReleaseNotes>Partial fix for lifetime management</PackageReleaseNotes>
     <IsAotCompatible>True</IsAotCompatible>
     <DisableRuntimeMarshalling>True</DisableRuntimeMarshalling>
-    <RuntimeIdentifiers>win-x64;win-x86;win-arm64;$(RuntimeIdentifiers)</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <AnalysisLevel>9.0-all</AnalysisLevel>
     <Platforms>x86;x64;ARM64</Platforms>
     <Nullable>enable</Nullable>

--- a/src/TaskDialog/TaskDialog.csproj
+++ b/src/TaskDialog/TaskDialog.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net9.0-windows10.0.22000</TargetFramework>
-    <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <AssemblyName>TaskDialog</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <PackageId>TaskDialog</PackageId>

--- a/src/WixToolset.Dtf.Compression.Cab/WixToolset.Dtf.Compression.Cab.csproj
+++ b/src/WixToolset.Dtf.Compression.Cab/WixToolset.Dtf.Compression.Cab.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0-windows10.0.22000</TargetFramework>
-    <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <IsThirdPartyProject>true</IsThirdPartyProject>
     <Nullable>disable</Nullable>
     <Platforms>AnyCPU;ARM64</Platforms>

--- a/src/WixToolset.Dtf.Compression/WixToolset.Dtf.Compression.csproj
+++ b/src/WixToolset.Dtf.Compression/WixToolset.Dtf.Compression.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0-windows10.0.22000</TargetFramework>
-    <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <IsThirdPartyProject>true</IsThirdPartyProject>
     <Nullable>disable</Nullable>
     <Platforms>AnyCPU;ARM64</Platforms>

--- a/src/WixToolset.Dtf.WindowsInstaller/WixToolset.Dtf.WindowsInstaller.csproj
+++ b/src/WixToolset.Dtf.WindowsInstaller/WixToolset.Dtf.WindowsInstaller.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0-windows10.0.22000</TargetFramework>
-    <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <IsThirdPartyProject>true</IsThirdPartyProject>
     <Nullable>disable</Nullable>
     <NoWarn>CA1065</NoWarn>


### PR DESCRIPTION
This PR fixes two issues:

* GitHub Actions was issuing a deprecation warning during release builds due to the use of outdated syntax in the workflow.
* The release build process was failing because the list of platforms and runtime identifiers did not match.