### PR TITLE
Fix issues in release workflow

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -57,7 +57,7 @@ jobs:
                   $manifest.Save('.\src\MSIExtract.AppxPackage\Package.appxmanifest')
                 }
 
-                echo "version=$version" >> $GITHUB_OUTPUT
+                echo "version=$version" >> $env:GITHUB_OUTPUT
 
             - name: Nerdbank.GitVersioning
               uses: dotnet/nbgv@master

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -16,7 +16,8 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         outputs:
-            release_upload_url: ${{ steps.create_release_notes.outputs.upload_url }}
+            release_name: ${{ steps.create_release_notes.name }}
+            release_tag_name: ${{ steps.create_release_notes.tag_name }}
 
     build:
         runs-on: windows-latest
@@ -95,22 +96,15 @@ jobs:
                   Write-Error "Could not find any msixbundle files"
                 }
 
-            - name: Upload Store Assets
-              uses: actions/upload-release-asset@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Create Release
+              # This exact commit of this fork is used because it fixes a bug that would
+              # cause the workflow to fail if a draft of the release already exists (which
+              # it always will because we use release-drafter).
+              uses: stephenway/action-gh-release@ef35f3531735d05ee289420f24b6aa256c112082
               with:
-                  upload_url: ${{ needs.create_release_notes.outputs.release_upload_url }}
-                  asset_path: bin/AppxPackages/MSIViewer_${{ steps.update_version.outputs.version }}.msixupload
-                  asset_name: "MSIViewer_${{ steps.update_version.outputs.version }}_Store.msixupload"
-                  asset_content_type: application/zip
-
-            - name: Upload Sideload Assets
-              uses: actions/upload-release-asset@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                  upload_url: ${{ needs.create_release_notes.outputs.release_upload_url }}
-                  asset_path: bin/AppxPackages/MSIViewer_${{ steps.update_version.outputs.version }}_Sideload.msixbundle
-                  asset_name: "MSIViewer_${{ steps.update_version.outputs.version }}_Sideload.msixbundle"
-                  asset_content_type: application/zip
+                draft: true
+                name: ${{ needs.create_release_notes.outputs.release_name }}
+                tag_name: ${{ needs.create_release_notes.outputs.release_tag_name }}
+                files: |
+                  bin/AppxPackages/MSIViewer_${{ steps.update_version.outputs.version }}.msixupload
+                  bin/AppxPackages/MSIViewer_${{ steps.update_version.outputs.version }}_Sideload.msixbundle


### PR DESCRIPTION
This PR does two things:

* It fixes an oversight in the use of the `$GITHUB_OUTPUT` variable. Since this is an environment variable, it must be accessed from PowerShell as `$env:GITHUB_OUTPUT`. This fixes an issue that was causing the asset files to have names without a version.
* It removes the deprecated `actions/upload-release-asset` action. Per the README in that repo, the `softprops/action-gh-release` workflow should be used instead. However, that repo appears to be unmaintained. It also contains a bug that would cause the workflow to fail if the release in question already exists — which it always will, since we are using release-drafter. The `stephenway/action-gh-release` fork contains a fix for this, but the fix is not yet merged into the main branch there, so I had to pin it to a specific commit.

Note that the release is still marked as a draft after the assets are uploaded, to allow for a final manual check before publishing it.