### PR TITLE
Add missing permission to release workflow

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   id-token: write
   attestations: write
+  contents: write
 
 jobs:
     create_release_notes:


### PR DESCRIPTION
This was causing the workflow to fail, but not abort.