### PR TITLE
Don’t update duplicate SBOM

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -88,7 +88,7 @@ jobs:
               uses: anchore/sbom-action@v0
               with:
                 path: bin/MSIExtract/ARM64/Release
-                output-file: bin/MSIExtract.spdx.json
+                artifact-name: MSIViewer-${{ github.ref_name }}.spdx.json
 
             - name: Upload Release Assets
               # This exact commit of this fork is used because it fixes a bug that would

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -100,7 +100,6 @@ jobs:
                 name: 'MSI Viewer ${{ github.ref_name }}'
                 tag_name: ${{ github.ref_name }}
                 files: |
-                  bin/MSIExtract.spdx.json
                   bin/AppxPackages/MSIViewer_${{ steps.update_version.outputs.version }}.msixupload
                   bin/AppxPackages/MSIViewer_${{ steps.update_version.outputs.version }}_Sideload.msixbundle
 


### PR DESCRIPTION
Also gave the SBOM file a better name.