### PR TITLE
Revert "Give SBOM file a better name"

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -88,7 +88,7 @@ jobs:
               uses: anchore/sbom-action@v0
               with:
                 path: bin/MSIExtract/ARM64/Release
-                artifact-name: MSIViewer-${{ github.ref_name }}.spdx.json
+                output-file: bin/MSIExtract.spdx.json
 
             - name: Upload Release Assets
               # This exact commit of this fork is used because it fixes a bug that would


### PR DESCRIPTION
This change broke the attestation steps, because I never updated them to use the new path (which is now undefined).

This reverts commit 660fbbc9bb31234e35743702c435a1bd1ea33b46.