### PR TITLE
Fix error in release workflow

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -43,8 +43,8 @@ jobs:
                   exit 1
                 }
 
-                $version = $match.Groups[1]
-                $suffix = $match.Groups[2]
+                $version = $match.Groups[1].Value
+                $suffix = $match.Groups[2].Value
 
                 echo "version=$version" >> $env:GITHUB_OUTPUT
 

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -23,9 +23,6 @@ jobs:
               with:
                   dotnet-version: "9.0"
 
-            - name: Configure Visual Studio
-              uses: microsoft/setup-msbuild@v2
-
             - name: Update Versions
               id: update_version
               run: |


### PR DESCRIPTION
Also removed a now-unused step from the release workflow, since we no longer use or require Visual Studio.