### PR TITLE
Fix path to application in shell extension class

### DIFF
--- a/src/MSIExtract/ShellExtension/MSIViewerOpenCommand.cs
+++ b/src/MSIExtract/ShellExtension/MSIViewerOpenCommand.cs
@@ -52,7 +52,7 @@ namespace MSIExtract.ShellExtension
 
             foreach (string msiPath in selectedFiles.Where(IsMSIFile))
             {
-                string exePath = Path.Combine(Package.Current.InstalledLocation.Path, "MSIExtract", "MSIExtract.exe");
+                string exePath = Path.Combine(Package.Current.InstalledLocation.Path, "MSIExtract.exe");
 
                 var processInfo = new ProcessStartInfo();
                 processInfo.FileName = exePath;


### PR DESCRIPTION
This path changed in #177. I fixed the path to the program in `MSIViewerOpenCommand.GetIcon()`, but not in the function that actually opens the file.