### PR TITLE
Bump actions task versions and set up Dependabot for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
           interval: daily
           time: "00:00"
           timezone: America/Detroit
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: daily
+          time: "00:00"
+          timezone: America/Detroit

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -14,12 +14,12 @@ jobs:
         runs-on: windows-latest
         steps:
             - name: Clone
-              uses: actions/checkout@v2
+              uses: actions/checkout@v6.0.3
               with:
                   fetch-depth: 0
 
             - name: Install .NET
-              uses: actions/setup-dotnet@v1
+              uses: actions/setup-dotnet@v5.3.0
               with:
                   dotnet-version: "9.0"
 
@@ -101,10 +101,7 @@ jobs:
                 output-file: bin/MSIExtract.spdx.json
 
             - name: Upload Release Assets
-              # This exact commit of this fork is used because it fixes a bug that would
-              # cause the workflow to fail if a draft of the release already exists (which
-              # it always will because we use release-drafter).
-              uses: stephenway/action-gh-release@ef35f3531735d05ee289420f24b6aa256c112082
+              uses: softprops/action-gh-release@v3.0.0
               with:
                 draft: true
                 name: 'MSI Viewer ${{ steps.update_version.outputs.version_no_v }}'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v6.0.3
       name: Clone
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v5.3.0
       name: Install .NET Core
       with:
         dotnet-version: "9.0"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
     - uses: actions/checkout@v6.0.3
       name: Clone
+      with:
+        fetch-depth: 0
     - uses: actions/setup-dotnet@v5.3.0
       name: Install .NET Core
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,13 +15,11 @@ jobs:
       name: Install .NET Core
       with:
         dotnet-version: "9.0"
-    - uses: microsoft/setup-msbuild@v2
-      name: Configure Visual Studio
     - name: Restore
       working-directory: ./src
       run: |
-        & MSBuild.exe /nologo /t:Restore
+        dotnet restore
     - name: Build
       working-directory: ./src/MSIExtract
       run: |
-        & MSBuild.exe /nologo /m /p:Configuration=Release /p:Platform=x64
+        dotnet build -c Release


### PR DESCRIPTION
While running the 3.1.2 release build, GitHub warned me that several GitHub Actions tasks use a now-deprecated version of the Node.js runtime. I have bumped those tasks to the latest available tag. I also no longer need a fork of softprops/action-gh-release because I am no longer using release-drafter. This PR also enables Dependabot for GitHub Actions tasks, so hopefully this issue will not recur in the future.

Also cleaned up a couple of Visual Studio leftovers in the CI workflow.