### PR TITLE
Use cache-hit parameter in CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,6 +37,7 @@ jobs:
 
     - uses: actions/cache/restore@v6.1.0
       name: Download Cached NuGet Packages
+      id: cache
       with:
          path: ~/.nuget/packages
          key: ${{ runner.os }}-nuget-${{ hashFiles('src/**/packages.lock.json') }}
@@ -44,12 +45,14 @@ jobs:
            ${{ runner.os }}-nuget-
 
     - name: Restore
+      if: steps.cache.outputs.cache-hit != 'true'
       working-directory: ./src
       run: |
         dotnet restore
 
     - uses: actions/cache/save@v6.1.0
       name: Save Cached NuGet Packages
+      if: steps.cache.outputs.cache-hit != 'true'
       with:
          path: ~/.nuget/packages
          key: ${{ runner.os }}-nuget-${{ hashFiles('src/**/packages.lock.json') }}


### PR DESCRIPTION
This fixes a warning that sometimes appears during the Save Cached NuGet Packages step if the cached data has not changed, and it also skips NuGet restore if what it would restore was downloaded from the cache.