### PR TITLE
Enable localization using Sunburst.MRTCore

### DIFF
--- a/src/MSIExtract/App.xaml.cs
+++ b/src/MSIExtract/App.xaml.cs
@@ -12,15 +12,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 
-using KPreisser.UI;
-
 using MSIExtract.ShellExtension;
 using MSIExtract.Views;
 
 using Shmuelie.WinRTServer;
-
-using Windows.ApplicationModel;
-using Windows.ApplicationModel.Activation;
 
 namespace MSIExtract
 {

--- a/src/MSIExtract/Controls/FileNameConverter.cs
+++ b/src/MSIExtract/Controls/FileNameConverter.cs
@@ -56,18 +56,27 @@ namespace MSIExtract.Controls
                 throw new ArgumentException("Path must be rooted", nameof(value));
             }
 
-            Shell32.IShellItem2? item = Shell32.SHCreateItemFromParsingName<Shell32.IShellItem2>(path);
-            ArgumentNullException.ThrowIfNull(item);
-
-            Shell32.SIGDN sigdn = DisplayMode switch
+            try
             {
-                FileNameDisplayMode.Default => Shell32.SIGDN.SIGDN_NORMALDISPLAY,
-                FileNameDisplayMode.FullPath => Shell32.SIGDN.SIGDN_FILESYSPATH,
-                FileNameDisplayMode.NameOnly => Shell32.SIGDN.SIGDN_PARENTRELATIVEPARSING,
-                _ => throw new InvalidOperationException($"Unexpected {nameof(FileNameDisplayMode)}")
-            };
+                Shell32.IShellItem2? item = Shell32.SHCreateItemFromParsingName<Shell32.IShellItem2>(path);
+                ArgumentNullException.ThrowIfNull(item);
 
-            return item.GetDisplayName(sigdn);
+                Shell32.SIGDN sigdn = DisplayMode switch
+                {
+                    FileNameDisplayMode.Default => Shell32.SIGDN.SIGDN_NORMALDISPLAY,
+                    FileNameDisplayMode.FullPath => Shell32.SIGDN.SIGDN_FILESYSPATH,
+                    FileNameDisplayMode.NameOnly => Shell32.SIGDN.SIGDN_PARENTRELATIVEPARSING,
+                    _ => throw new InvalidOperationException($"Unexpected {nameof(FileNameDisplayMode)}")
+                };
+
+                return item.GetDisplayName(sigdn);
+            }
+            catch
+            {
+                // If the path doesn't exist, SHCreateItemFromParsingName() will throw
+                // a FileNotFoundException. Fall back to a simple System.IO.Path manipulation.
+                return Path.GetFileName(path);
+            }
         }
 
         /// <summary>

--- a/src/MSIExtract/Controls/Localization/LocalizeExtension.cs
+++ b/src/MSIExtract/Controls/Localization/LocalizeExtension.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) William Kent. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows;
+using System.Windows.Markup;
+using System.Xaml;
+
+namespace MSIExtract.Controls.Localization
+{
+    /// <summary>
+    /// A <see cref="MarkupExtension"/> that looks a string up from a <see cref="PRIResourceLoader"/>.
+    /// </summary>
+    public sealed class LocalizeExtension : MarkupExtension
+    {
+        /// <summary>
+        /// Gets or sets the resource key to use. If unset, this will be automatically derived from a
+        /// combination of the target object's <see cref="UIElement.Uid"/> and the name
+        /// of the property the receiver is providing a value for.
+        /// </summary>
+        public string? Key { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the <see cref="PRIResourceLoader"/> instance to use. If unset, this's instance's
+        /// properties will be automatically derived using the root type (to locate the assembly) and its
+        /// unqualified name as the <see cref="PRIResourceLoader.ResourceMap"/>.
+        /// </summary>
+        public PRIResourceLoader? Loader { get; set; } = null;
+
+        /// <inheritdoc/>
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            ArgumentNullException.ThrowIfNull(serviceProvider);
+
+            if (Loader == null)
+            {
+                IRootObjectProvider? rootObjectProvider = (IRootObjectProvider?)serviceProvider.GetService(typeof(IRootObjectProvider));
+                if (rootObjectProvider == null)
+                {
+                    throw new InvalidOperationException("Loader is not set and IRootObjectProvider could not be obtained");
+                }
+
+                Type type = rootObjectProvider.RootObject.GetType();
+                Loader = new PRIResourceLoader(type, type.Name);
+            }
+
+            string? key = this.Key;
+            if (key == null)
+            {
+                IProvideValueTarget? valueTarget = (IProvideValueTarget?)serviceProvider.GetService(typeof(IProvideValueTarget));
+                if (valueTarget == null)
+                {
+                    throw new InvalidOperationException("Could not get IProvideValueTarget");
+                }
+
+                if (valueTarget.TargetObject is UIElement element)
+                {
+                    if (string.IsNullOrEmpty(element.Uid))
+                    {
+                        throw new InvalidOperationException("x:Uid must be set to use automatic key lookup");
+                    }
+
+                    string propertyName = valueTarget.TargetProperty switch
+                    {
+                        DependencyProperty prop => prop.Name,
+                        System.Reflection.PropertyInfo prop => prop.Name,
+                        _ => throw new InvalidOperationException("Unexpected TargetProperty type")
+                    };
+
+                    key = element.Uid + "." + propertyName;
+                }
+            }
+
+            if (key == null)
+            {
+                throw new InvalidOperationException("Key not specified and could not be looked up automatically");
+            }
+
+            return Loader.GetString(key);
+        }
+    }
+}

--- a/src/MSIExtract/Controls/Localization/PRIResourceLoader.cs
+++ b/src/MSIExtract/Controls/Localization/PRIResourceLoader.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) William Kent. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Microsoft.ApplicationModel.Resources;
+
+namespace MSIExtract.Controls.Localization;
+
+/// <summary>
+/// Provides a way to load string and binary resources from a *.pri file.
+/// </summary>
+/// <remarks>
+/// The *.pri file used will be located using the path to the assembly containing the
+/// <see cref="TypeInTargetAssembly"/>. If the assembly is named <c>MyAssembly.dll</c>,
+/// the file <c>MyAssembly.pri</c> in the same directory will be queried.
+/// </remarks>
+public class PRIResourceLoader
+{
+    private ResourceManager? resourceManager;
+    private ResourceMap? resourceLoader;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PRIResourceLoader"/> class with no properties set.
+    /// </summary>
+    /// <remarks>
+    /// Using <see cref="PRIResourceLoader"/> in a XAML resource dictionary requires
+    /// that there be a public parameterless constructor.
+    /// </remarks>
+    public PRIResourceLoader()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PRIResourceLoader"/> class.
+    /// </summary>
+    /// <param name="typeInTargetAssembly">
+    /// A type in the assembly that owns the *.pri file to use.
+    /// </param>
+    /// <param name="resourceMap">
+    /// A string designating the submap of the *.pri file to reference.
+    /// </param>
+    public PRIResourceLoader(Type typeInTargetAssembly, string resourceMap)
+    {
+        this.TypeInTargetAssembly = typeInTargetAssembly;
+        this.ResourceMap = resourceMap;
+    }
+
+    /// <summary>
+    /// Gets or sets a type in the assembly that owns the *.pri file to use.
+    /// </summary>
+    public Type? TypeInTargetAssembly { get; set; } = null;
+
+    /// <summary>
+    /// Gets or sets a string designating the submap of the *.pri file to reference.
+    /// </summary>
+    public string ResourceMap { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Looks up a string. An exception will be thrown if the <paramref name="key"/> is not found.
+    /// </summary>
+    /// <param name="key">
+    /// The key to look up in the <see cref="ResourceMap"/>.
+    /// </param>
+    /// <returns>
+    /// A <see cref="string"/>, or a placeholder if the *.pri file could not be loaded
+    /// (for WPF designer support).
+    /// </returns>
+    public string GetString(string key)
+    {
+        if (this.resourceLoader == null)
+        {
+            this.LoadResources();
+        }
+
+        if (this.resourceLoader == null)
+        {
+            // If the resource loader is still null after being loaded, that means that the
+            // PRI file could not be found. Return a fallback in that case.
+            return "{" + key + "}";
+        }
+
+        ResourceCandidate candidate = this.resourceLoader.GetValue(key);
+        return candidate.ValueAsString;
+    }
+
+    /// <summary>
+    /// Looks up an embedded binary file as a <see cref="Stream"/>. An exception will be thrown
+    /// if the <paramref name="key"/> is not found.
+    /// </summary>
+    /// <param name="key">
+    /// The key to look up in the <see cref="ResourceMap"/>.
+    /// </param>
+    /// <returns>
+    /// A <see cref="Stream"/> instance, or <c>null</c> if the *.pri file could not be loaded.
+    /// </returns>
+    public Stream? GetStream(string key)
+    {
+        if (this.resourceLoader == null)
+        {
+            this.LoadResources();
+        }
+
+        if (this.resourceLoader == null)
+        {
+            return null;
+        }
+
+        ResourceCandidate candidate = this.resourceLoader.GetValue(key);
+        return new MemoryStream(candidate.ValueAsBytes);
+    }
+
+    private void LoadResources()
+    {
+        if (TypeInTargetAssembly == null)
+        {
+            return;
+        }
+
+        if (ResourceMap == null)
+        {
+            return;
+        }
+
+        string path = Path.ChangeExtension(this.TypeInTargetAssembly.Assembly.Location, ".pri");
+        if (!File.Exists(path))
+        {
+            return;
+        }
+
+        this.resourceManager = new ResourceManager(path);
+        this.resourceLoader = this.resourceManager.MainResourceMap.GetSubtree(ResourceMap);
+    }
+}

--- a/src/MSIExtract/MSIExtract.csproj
+++ b/src/MSIExtract/MSIExtract.csproj
@@ -17,6 +17,8 @@
     <PublishReadyToRun>False</PublishReadyToRun>
 
     <IncludePackageReferencesDuringMarkupCompilation>false</IncludePackageReferencesDuringMarkupCompilation>
+    <MRTCoreResourceRoot>PRIResources</MRTCoreResourceRoot>
+    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,6 +31,7 @@
     <PackageReference Include="Dirkster.MRULib" Version="1.3.0" />
     <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
     <PackageReference Include="Vanara.PInvoke.Shell32" Version="4.0.1" />
+    <PackageReference Include="Sunburst.MRTCore" Version="2.0.4" />
 
     <ProjectReference Include="..\AcrylicWindow\AcrylicWindow.csproj" />
     <ProjectReference Include="..\MSIExtract.Core\MSIExtract.Core.csproj" />

--- a/src/MSIExtract/PRIResources/ExtractFilesView.lang-en.resjson
+++ b/src/MSIExtract/PRIResources/ExtractFilesView.lang-en.resjson
@@ -1,0 +1,12 @@
+// Copyright (c) William Kent. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+{
+  "ListViewItem.FileLabel.Text": "File:",
+  "ListViewItem.DirectoryLabel.Text": "Directory:",
+
+  "SelectAllButton.Content": "Select _All",
+  "SelectNoneButton.Content": "_Deselect All",
+  "ExtractButton.Content": "Extract",
+  "SearchPlaceholderLabel.Text": "Enter Search Term Here"
+}

--- a/src/MSIExtract/PRIResources/MainWindow.lang-en.resjson
+++ b/src/MSIExtract/PRIResources/MainWindow.lang-en.resjson
@@ -1,0 +1,29 @@
+// Copyright (c) William Kent. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+{
+  "Window.Title": "MSI Viewer",
+
+  "FileMenu.Header": "_File",
+  "OpenMenuItem.Header": "_Open...",
+  "OpenRecentMenu.Header": "_Recent Files",
+  "ClearRecentsMenuItem.Header": "_Clear List",
+  "ExitMenuItem.Header": "E_xit",
+
+  "HelpMenu.Header": "_Help",
+  "PrivacyPolicyMenuItem.Header": "_Privacy Policy",
+  "AboutMenuItem.Header": "_About MSI Viewer",
+
+  "FilePicker.Header": "File:",
+
+  "FilesTab.Header": "Files",
+  "TablesTab.Header": "Tables",
+
+  "FileNotFoundDialog.Instruction": "The file \"{0}\" does not exist.",
+  "FileNotFoundDialog.Text": "Would you like to remove it from the Recent Files list?",
+  "FileNotFoundDialog.RemoveButtonText": "Remove",
+  "InvalidFileDialog.Instruction": "Could not open \"{0}\".",
+  "InvalidFileDialog.Text": "This file may not be a valid MSI or MSM file.",
+  "AboutDialog.Title": "About MSI Viewer",
+  "AboutDialog.Text": "Copyright © 2019-2020 William Kent. Licensed under the MIT License.\r\n\r\n<a href=\"github\">View on GitHub</a>\r\n<a href=\"tpn\">Third-Party Notices</a>\r\n\r\nBuild {0}"
+}

--- a/src/MSIExtract/PRIResources/SharedControls.resjson
+++ b/src/MSIExtract/PRIResources/SharedControls.resjson
@@ -1,0 +1,7 @@
+// Copyright (c) William Kent. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+{
+  "FilePicker.FallbackText": "<None>",
+  "FilePicker.ChooseButton.Text": "Choose..."
+}

--- a/src/MSIExtract/Theme/FilePicker.xaml
+++ b/src/MSIExtract/Theme/FilePicker.xaml
@@ -1,7 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:System="clr-namespace:System;assembly=System.Runtime"
-                    xmlns:Controls="clr-namespace:MSIExtract.Controls">
+                    xmlns:Controls="clr-namespace:MSIExtract.Controls"
+                    xmlns:loc="clr-namespace:MSIExtract.Controls.Localization">
     <Style TargetType="Controls:FilePicker" x:Key="{x:Type Controls:FilePicker}">
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="UseLayoutRounding" Value="True" />
@@ -13,8 +14,9 @@
                     <Border x:Name="Root" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}" Margin="{TemplateBinding Margin}" Padding="{TemplateBinding Padding}">
                         <Border.Resources>
+                            <loc:PRIResourceLoader x:Key="StringLoader" TypeInTargetAssembly="{x:Type Controls:FilePicker}" ResourceMap="SharedControls" />
                             <System:String x:Key="NoneText">&lt;None&gt;</System:String>
-                            <Controls:FileNameConverter x:Key="FileNameConverter" DisplayMode="FullPath" FallbackValue="{StaticResource NoneText}" />
+                            <Controls:FileNameConverter x:Key="FileNameConverter" DisplayMode="FullPath" FallbackValue="{loc:Localize Key=FilePicker.FallbackText,Loader={StaticResource StringLoader}}" />
                         </Border.Resources>
                         
                         <Grid>
@@ -29,7 +31,7 @@
                             <Image x:Name="PART_Icon" Grid.Column="1" Width="16" Height="16" VerticalAlignment="Top" Margin="0 7 4 0" />
                             <TextBlock x:Name="PART_Text" Grid.Column="2" HorizontalAlignment="Stretch" VerticalAlignment="Top" TextWrapping="Wrap" Margin="0 4 4 0"
                                        Text="{TemplateBinding FilePath, Converter={StaticResource FileNameConverter}}" />
-                            <Button x:Name="PART_ChooseButton" Content="_Choose..." Grid.Column="3" VerticalAlignment="Top" />
+                            <Button x:Name="PART_ChooseButton" Content="{loc:Localize Key=FilePicker.ChooseButton.Text,Loader={StaticResource StringLoader}}" Grid.Column="3" VerticalAlignment="Top" />
                         </Grid>
                     </Border>
 

--- a/src/MSIExtract/Views/ExtractFilesView.xaml
+++ b/src/MSIExtract/Views/ExtractFilesView.xaml
@@ -6,6 +6,7 @@
              xmlns:Controls="clr-namespace:MSIExtract.Controls"
              xmlns:Views="clr-namespace:MSIExtract.Views"
              xmlns:Msi="clr-namespace:MSIExtract.Msi;assembly=MSIExtract.Core"
+             xmlns:loc="clr-namespace:MSIExtract.Controls.Localization"
              d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{StaticResource DesignTimeAppModel}">
     <UserControl.CommandBindings>
         <CommandBinding Command="{x:Static ApplicationCommands.SelectAll}" Executed="SelectAllCommand_Executed" CanExecute="SelectionCommand_CanExecute" />
@@ -22,13 +23,13 @@
                 </Grid.RowDefinitions>
 
                 <TextBlock Grid.Row="0" TextWrapping="Wrap">
-                    <Run>File:</Run>
+                    <Run x:Uid="ListViewItemFileLabel" Text="{loc:Localize Key=ListViewItem.FileLabel.Text}" />
                     <TextBlock FontWeight="Bold"
                         Controls:HighlightTermBehavior.TermToBeHighlighted="{Binding Path=DataContext.FilterText, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Mode=OneWay}"
                         Controls:HighlightTermBehavior.Text="{Binding Path=LongFileName, Mode=OneWay}" />
                 </TextBlock>
                 <TextBlock Grid.Row="1" TextWrapping="Wrap">
-                    <Run>Directory:</Run>
+                    <Run x:Uid="ListViewItem.DirectoryLabel" Text="{loc:Localize Key=ListViewItem.DirectoryLabel.Text}" />
                     <TextBlock
                         Controls:HighlightTermBehavior.TermToBeHighlighted="{Binding Path=DataContext.FilterText, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Mode=OneWay}"
                         Controls:HighlightTermBehavior.Text="{Binding Path=Directory.FullPath, Mode=OneWay}" />
@@ -36,13 +37,13 @@
             </Grid>
         </DataTemplate>
     </UserControl.Resources>
-    
+
     <Grid Margin="8">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        
+
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
@@ -54,11 +55,11 @@
                   BorderBrush="{DynamicResource {x:Static SystemColors.AccentColorLight2BrushKey}}" BorderThickness="1">
         </ListView>
 
-        <Button Content="Select _All" Grid.Row="1" Grid.Column="0" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="0 8 8 0" Command="{x:Static ApplicationCommands.SelectAll}" />
-        <Button Content="_Deselect All" Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="0 8 4 0" Command="{x:Static Views:ExtractFilesView.SelectNoneCommand}" />
-        <Button Content="Extract" Grid.Row="1" Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="4 8 0 0" IsDefault="True" Command="{x:Static Views:ExtractFilesView.ExtractCommand}" Style="{StaticResource AccentButtonStyle}" />
+        <Button x:Uid="SelectAllButton" Content="{loc:Localize}" Grid.Row="1" Grid.Column="0" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="0 8 8 0" Command="{x:Static ApplicationCommands.SelectAll}" />
+        <Button x:Uid="SelectNoneButton" Content="{loc:Localize}" Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="0 8 4 0" Command="{x:Static Views:ExtractFilesView.SelectNoneCommand}" />
+        <Button x:Uid="ExtractButton" Content="{loc:Localize}" Grid.Row="1" Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="4 8 0 0" IsDefault="True" Command="{x:Static Views:ExtractFilesView.ExtractCommand}" Style="{StaticResource AccentButtonStyle}" />
         <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}" Name="FilterFileListView" Grid.Row="1" Grid.Column="2" HorizontalAlignment="Left" Margin="4,8,0,0" TextWrapping="NoWrap" VerticalAlignment="Bottom" Width="320" IsEnabled="{Binding IsMsiLoaded}" />
-        <TextBlock IsHitTestVisible="False" Grid.Row="1" Grid.Column="2" Text="Enter Search Term Here" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="16,8,0,0" Foreground="{x:Static SystemColors.GrayTextBrush}">
+        <TextBlock x:Uid="SearchPlaceholderLabel" IsHitTestVisible="False" Grid.Row="1" Grid.Column="2" Text="{loc:Localize}" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="16,8,0,0" Foreground="{x:Static SystemColors.GrayTextBrush}">
             <TextBlock.Style>
                 <Style TargetType="{x:Type TextBlock}">
                     <Setter Property="Visibility" Value="Collapsed"/>

--- a/src/MSIExtract/Views/MainWindow.xaml
+++ b/src/MSIExtract/Views/MainWindow.xaml
@@ -19,8 +19,6 @@
     </AcrylicWindow.CommandBindings>
 
     <AcrylicWindow.Resources>
-        <loc:PRIResourceLoader x:Key="StringLoader" TypeInTargetAssembly="{x:Type Views:MainWindow}" ResourceMap="MainWindow" />
-
         <Controls:MRUMenuItemEnabledConverter x:Key="MRUMenuItemEnabledConverter" />
         <Controls:FileNameConverter x:Key="FileNameConverter" DisplayMode="NameOnly" />
 

--- a/src/MSIExtract/Views/MainWindow.xaml
+++ b/src/MSIExtract/Views/MainWindow.xaml
@@ -5,6 +5,7 @@
                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d"
                xmlns:Controls="clr-namespace:MSIExtract.Controls"
                xmlns:Views="clr-namespace:MSIExtract.Views"
+               xmlns:loc="clr-namespace:MSIExtract.Controls.Localization"
                xmlns:ComponentModel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
                Title="MSI Viewer" Height="450" Width="800" MinHeight="450" MinWidth="800" Icon="../Setup.ico"
                FrameBackground="SupportingWindow"
@@ -18,6 +19,8 @@
     </AcrylicWindow.CommandBindings>
 
     <AcrylicWindow.Resources>
+        <loc:PRIResourceLoader x:Key="StringLoader" TypeInTargetAssembly="{x:Type Views:MainWindow}" ResourceMap="MainWindow" />
+
         <Controls:MRUMenuItemEnabledConverter x:Key="MRUMenuItemEnabledConverter" />
         <Controls:FileNameConverter x:Key="FileNameConverter" DisplayMode="NameOnly" />
 
@@ -35,14 +38,16 @@
         </Grid.RowDefinitions>
 
         <Menu Grid.Row="0" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" BorderThickness="0 0 0 1">
-            <MenuItem Header="_File">
-                <MenuItem Header="_Open..." Command="{x:Static ApplicationCommands.Open}" />
-                <MenuItem Header="_Recent Files" IsEnabled="{Binding MRUModel, Converter={StaticResource MRUMenuItemEnabledConverter}}">
+            <MenuItem x:Uid="FileMenu" Header="{loc:Localize}">
+                <MenuItem x:Uid="OpenMenuItem" Header="{loc:Localize}"
+                          Command="{x:Static ApplicationCommands.Open}" />
+                <MenuItem x:Uid="OpenRecentMenu" Header="{loc:Localize}"
+                          IsEnabled="{Binding MRUModel, Converter={StaticResource MRUMenuItemEnabledConverter}}">
                     <MenuItem.ItemsSource>
                         <CompositeCollection>
                             <CollectionContainer Collection="{Binding Source={StaticResource MRUCollectionViewSource}, Mode=OneWay}" />
                             <Separator />
-                            <MenuItem Header="_Clear List" Command="{x:Static Views:MainWindow.ClearRecentFileListCommand}" />
+                            <MenuItem x:Uid="ClearRecentsMenuItem" Header="{loc:Localize}" Command="{x:Static Views:MainWindow.ClearRecentFileListCommand}" />
                         </CompositeCollection>
                     </MenuItem.ItemsSource>
 
@@ -55,12 +60,13 @@
                     </MenuItem.ItemContainerStyle>
                 </MenuItem>
                 <Separator />
-                <MenuItem Header="E_xit" Command="{x:Static SystemCommands.CloseWindowCommand}" />
+                <MenuItem x:Uid="ExitMenuItem" Header="{loc:Localize}"
+                          Command="{x:Static SystemCommands.CloseWindowCommand}" />
             </MenuItem>
 
-            <MenuItem Header="_Help">
-                <MenuItem Header="_Privacy Policy" Click="PrivacyMenuItem_Click" />
-                <MenuItem Header="_About MSI Viewer" Click="AboutMenuItem_Click" />
+            <MenuItem x:Uid="HelpMenu" Header="{loc:Localize}">
+                <MenuItem x:Uid="PrivacyPolicyMenuItem" Header="{loc:Localize}" Click="PrivacyMenuItem_Click" />
+                <MenuItem x:Uid="AboutMenuItem" Header="{loc:Localize}" Click="AboutMenuItem_Click" />
             </MenuItem>
         </Menu>
 
@@ -70,14 +76,14 @@
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
 
-            <Controls:FilePicker x:Name="FilePicker" Grid.Row="0" Margin="6 4 4 0" Header="File:" HorizontalAlignment="Stretch"
+            <Controls:FilePicker x:Name="FilePicker" x:Uid="FilePicker" Grid.Row="0" Margin="6 4 4 0" Header="{loc:Localize}" HorizontalAlignment="Stretch"
                                  FilePath="{Binding Path=MsiPath, Mode=TwoWay}" OpenDialogFilter="MSI Files (*.msi, *.msm)|*.msi;*.msm"
                                  OpenDialogClientGuid="fe9c4d64-6f2d-4bee-8220-ece48200404f" />
             <TabControl Grid.Row="1" Margin="8" BorderBrush="{DynamicResource {x:Static SystemColors.AccentColorLight1BrushKey}}" BorderThickness="1">
-                <TabItem Header="Files">
+                <TabItem x:Uid="FilesTab" Header="{loc:Localize}">
                     <Views:ExtractFilesView />
                 </TabItem>
-                <TabItem Header="Tables">
+                <TabItem x:Uid="TablesTab" Header="{loc:Localize}">
                     <Views:TableView />
                 </TabItem>
             </TabControl>

--- a/src/MSIExtract/Views/MainWindow.xaml.cs
+++ b/src/MSIExtract/Views/MainWindow.xaml.cs
@@ -20,6 +20,8 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using KPreisser.UI;
 using MSIExtract.Controls;
+using MSIExtract.Controls.Localization;
+
 using Vanara.PInvoke;
 
 namespace MSIExtract.Views
@@ -44,6 +46,8 @@ namespace MSIExtract.Views
         /// </summary>
         public static readonly RoutedCommand OpenRecentFileCommand = Commands.CreateCommand("OpenRecentFile", typeof(MainWindow));
 
+        private readonly PRIResourceLoader stringLoader = new PRIResourceLoader(typeof(MainWindow), nameof(MainWindow));
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MainWindow"/> class.
         /// </summary>
@@ -51,6 +55,11 @@ namespace MSIExtract.Views
         {
             this.InitializeComponent();
             DataContext = new AppModel();
+
+            // A LocalizeExtension in the top-level element causes an exception because
+            // it is evaluated before our Resources directionary is created, thus giving
+            // it no way to locate its PRI file.
+            Title = stringLoader.GetString("Window.Title");
         }
 
         /// <summary>
@@ -88,12 +97,12 @@ namespace MSIExtract.Views
                 {
                     AllowCancel = true,
                     Title = "MSI Viewer",
-                    Instruction = $"The file {path} does not exist.",
-                    Text = "Would you like to remove it from the Recent Files list?",
+                    Instruction = string.Format(stringLoader.GetString("FileNotFoundDialog.Instruction"), path),
+                    Text = stringLoader.GetString("FileNotFoundDialog.Text"),
                     Icon = TaskDialogIcon.Get(TaskDialogStandardIcon.Warning),
                 };
 
-                TaskDialogCustomButton removeButton = new TaskDialogCustomButton("Remove");
+                TaskDialogCustomButton removeButton = new TaskDialogCustomButton(stringLoader.GetString("FileNotFoundDialog.RemoveButtonText"));
                 removeButton.DefaultButton = true;
                 page.CustomButtons.Add(removeButton);
                 page.StandardButtons.Add(TaskDialogResult.Cancel);
@@ -132,7 +141,7 @@ namespace MSIExtract.Views
         {
             static string GetTaskDialogInstruction()
             {
-                string appTitle = "MSI Viewer";
+                string appTitle = ThisAssembly.AssemblyTitle;
                 string versionString = ThisAssembly.AssemblyVersion;
 
                 if (versionString.EndsWith(".0.0", StringComparison.InvariantCulture))
@@ -150,13 +159,10 @@ namespace MSIExtract.Views
             TaskDialogPage page = new TaskDialogPage
             {
                 AllowCancel = true,
-                Title = "About MSI Viewer",
+                Title = stringLoader.GetString("AboutDialog.Title"),
                 Instruction = GetTaskDialogInstruction(),
                 Icon = TaskDialogIcon.Get(TaskDialogStandardIcon.Information),
-                Text = "Copyright © 2019-2020 William Kent. Licensed under the MIT License.\r\n\r\n" +
-                "<a href=\"github\">View on GitHub</a>\r\n" +
-                "<a href=\"tpn\">Third-Party Notices</a>\r\n\r\n" +
-                $"Build {ThisAssembly.AssemblyInformationalVersion}",
+                Text = string.Format(stringLoader.GetString("AboutDialog.Text"), ThisAssembly.AssemblyInformationalVersion),
                 EnableHyperlinks = true,
             };
             page.StandardButtons.Add(TaskDialogResult.OK);
@@ -191,9 +197,9 @@ namespace MSIExtract.Views
 
             TaskDialogPage page = new TaskDialogPage();
             page.AllowCancel = true;
-            page.Title = "MSI Viewer";
-            page.Instruction = $"Could not open \"{fileName}\".";
-            page.Text = "This file may not be a valid MSI or MSM file.";
+            page.Title = stringLoader.GetString("Window.Title");
+            page.Instruction = string.Format(stringLoader.GetString("InvalidFileDialog.Instruction"), fileName);
+            page.Text = stringLoader.GetString("InvalidFileDialog.Text");
             page.Icon = TaskDialogStandardIcon.Error;
             page.StandardButtons.Add(TaskDialogResult.OK);
 

--- a/src/MSIExtract/Views/MainWindow.xaml.cs
+++ b/src/MSIExtract/Views/MainWindow.xaml.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -81,17 +82,14 @@ namespace MSIExtract.Views
             var entry = (MRULib.MRU.Interfaces.IMRUEntryViewModel)e.Parameter;
             var model = (AppModel)DataContext;
 
-            try
-            {
-                model.MsiPath = entry.PathFileName;
-            }
-            catch (WixToolset.Dtf.WindowsInstaller.InstallerException)
+            void ShowFileMissingDialog(string path)
             {
                 TaskDialogPage page = new TaskDialogPage
                 {
                     AllowCancel = true,
                     Title = "MSI Viewer",
-                    Instruction = $"The file {entry.File.Name} does not exist. Would you like to remove it from the Recent Files list?",
+                    Instruction = $"The file {path} does not exist.",
+                    Text = "Would you like to remove it from the Recent Files list?",
                     Icon = TaskDialogIcon.Get(TaskDialogStandardIcon.Warning),
                 };
 
@@ -105,6 +103,22 @@ namespace MSIExtract.Views
                 {
                     model.RemoveMRUItem(entry);
                 }
+            }
+
+            if (!File.Exists(entry.PathFileName))
+            {
+                string fileName = System.IO.Path.GetFileName(entry.PathFileName);
+                ShowFileMissingDialog(fileName);
+                return;
+            }
+
+            try
+            {
+                model.MsiPath = entry.PathFileName;
+            }
+            catch (WixToolset.Dtf.WindowsInstaller.InstallerException)
+            {
+                ShowFileMissingDialog(entry.File.Name);
             }
         }
 

--- a/src/MSIExtract/packages.lock.json
+++ b/src/MSIExtract/packages.lock.json
@@ -49,6 +49,12 @@
         "resolved": "1.1.118",
         "contentHash": "Onx6ovGSqXSK07n/0eM3ZusiNdB6cIlJdabQhWGgJp3Vooy9AaLS/tigeybOJAobqbtggTamoWndz72JscZBvw=="
       },
+      "Sunburst.MRTCore": {
+        "type": "Direct",
+        "requested": "[2.0.4, )",
+        "resolved": "2.0.4",
+        "contentHash": "caLn7hYt2WafvE3DnfCk5uR+6rb+ctUo4rr07C8PrQ9qMVyaOcARTc4bboIvYid1Nhwf2wgtHi3w0I/JB7pGIg=="
+      },
       "Vanara.PInvoke.Shell32": {
         "type": "Direct",
         "requested": "[4.0.1, )",
@@ -254,7 +260,21 @@
         "type": "Project"
       }
     },
-    "net10.0-windows10.0.22000/win-arm64": {},
-    "net10.0-windows10.0.22000/win-x64": {}
+    "net10.0-windows10.0.22000/win-arm64": {
+      "Sunburst.MRTCore": {
+        "type": "Direct",
+        "requested": "[2.0.4, )",
+        "resolved": "2.0.4",
+        "contentHash": "caLn7hYt2WafvE3DnfCk5uR+6rb+ctUo4rr07C8PrQ9qMVyaOcARTc4bboIvYid1Nhwf2wgtHi3w0I/JB7pGIg=="
+      }
+    },
+    "net10.0-windows10.0.22000/win-x64": {
+      "Sunburst.MRTCore": {
+        "type": "Direct",
+        "requested": "[2.0.4, )",
+        "resolved": "2.0.4",
+        "contentHash": "caLn7hYt2WafvE3DnfCk5uR+6rb+ctUo4rr07C8PrQ9qMVyaOcARTc4bboIvYid1Nhwf2wgtHi3w0I/JB7pGIg=="
+      }
+    }
   }
 }

--- a/version.json
+++ b/version.json
@@ -2,7 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
   "version": "42.42",
   "publicReleaseRefSpec": [
-    "^refs/heads/master$",
     "^refs/heads/release/v?\\d+(?:\\.\\d+){1,2}(?:-[a-z0-9.-]+)?$",
     "^refs/tags/v\\d+(?:\\.\\d+){1,2}(?:-[a-z0-9.-]+)?$"
   ]

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.0",
+  "version": "42.42",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/release/v?\\d+(?:\\.\\d+){1,2}(?:-[a-z0-9.-]+)?$",


### PR DESCRIPTION
As the title says, this PR adds the infrastructure required to localize MSI Viewer with my [Sunburst.MRTCore NuGet package](https://github.com/wjk/Sunburst.MRTCore). Note that this PR does _not_ add any actual localizations for languages other than English.

Also updated the version numbers in the repo to be unrelated to MSI Viewer’s existing releases, since release builds have the version number updated automatically, and removed some unneeded using statements from App.xaml.cs.